### PR TITLE
Sponsor fix

### DIFF
--- a/src/components/SupportedBySection/SupportedBySection.jsx
+++ b/src/components/SupportedBySection/SupportedBySection.jsx
@@ -15,7 +15,10 @@ const SupportedBySection = ({ name, tag, theme }) => {
       theme={theme}
     >
       <p className={styles.details}>Interested in supporting us?</p>
-      <SiteButton className="btn btn-solid-red" href="https://cmpsc.uk/sponsor">
+      <SiteButton
+        className="btn btn-solid-red"
+        href="https://compsoc.dev/sponsor"
+      >
         Find Out More
       </SiteButton>
     </Section>

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,5 +1,5 @@
-/dc  https://dc.cmpsc.uk
-/discord  https://dc.cmpsc.uk
+/dc https://dc.cmpsc.uk
+/discord https://dc.cmpsc.uk
 
 /committee/current-committee /committee
 /committee/previous-committees /committee
@@ -8,11 +8,13 @@
 /committee/committee-2014-2015 /committee/#committee-2014-2015
 /committee/committee-2015-2016 /committee/#committee-2015-2016
 
-http://cmpsc.uk/*  https://computingsociety.co.uk/$1
-https://cmpsc.uk/*  https://computingsociety.co.uk/$1
-http://www.cmpsc.uk/*  https://computingsociety.co.uk/$1
-https://www.cmpsc.uk/*  https://computingsociety.co.uk/$1
-http://www.computingsociety.uk/*  https://computingsociety.co.uk/$1
-https://www.computingsociety.uk/*  https://computingsociety.co.uk/$1
-http://computingsociety-co-uk.pages.dev/* https://computingsociety.co.uk/$1
-https://computingsociety-co-uk.pages.dev/* https://computingsociety.co.uk/$1
+/sponsor https://compsoc.dev/sponsor
+
+http://cmpsc.uk/_ https://computingsociety.co.uk/$1
+https://cmpsc.uk/_ https://computingsociety.co.uk/$1
+http://www.cmpsc.uk/_ https://computingsociety.co.uk/$1
+https://www.cmpsc.uk/_ https://computingsociety.co.uk/$1
+http://www.computingsociety.uk/_ https://computingsociety.co.uk/$1
+https://www.computingsociety.uk/_ https://computingsociety.co.uk/$1
+http://computingsociety-co-uk.pages.dev/_ https://computingsociety.co.uk/$1
+https://computingsociety-co-uk.pages.dev/_ https://computingsociety.co.uk/$1


### PR DESCRIPTION
Fixed `/sponsor` route along with the creation of the shortlink https://compsoc.dev/sponsor